### PR TITLE
Krish/9-api-and-crud-for-pets

### DIFF
--- a/src/pages/api/v1/pets/[userId].ts
+++ b/src/pages/api/v1/pets/[userId].ts
@@ -1,5 +1,5 @@
 import { Pet } from "@/server/db/models";
-import { getTypedPets } from "@/server/service/pets";
+import { getTypedPets, typedUpdatePet } from "@/server/service/pets";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
@@ -7,16 +7,42 @@ export default async function handler(
   res: NextApiResponse,
 ) {
   const { userId } = req.query;
-  const { method } = req;
+  const { method, body } = req;
+
+  if (typeof userId !== "string" || isNaN(Number(userId))) {
+    return res.status(400).json({ error: "userId must be a number" });
+  }
 
   try {
     switch (method) {
       case "GET":
         const pet: Pet | null = await getTypedPets(Number(userId));
 
-        //Check if user has a pet
+        // Check if user has a pet
         if (pet) {
           res.status(200).json(pet);
+        } else {
+          res.status(404).json({ message: "This user doesn't have a pet" });
+        }
+        break;
+
+      case "PATCH":
+        // Validate the request body
+        if (!body || typeof body.name !== "string" || body.name.trim() === "") {
+          return res.status(400).json({
+            error:
+              "Invalid request body: 'name' is required and must be a non-empty string.",
+          });
+        }
+
+        const updatedPet: Pet | null = await typedUpdatePet(
+          Number(userId),
+          body,
+        );
+
+        // If null response, this user doesn't have a pet
+        if (updatedPet) {
+          res.status(200).json(updatedPet);
         } else {
           res.status(404).json({ message: "This user doesn't have a pet" });
         }

--- a/src/pages/api/v1/pets/[userId].ts
+++ b/src/pages/api/v1/pets/[userId].ts
@@ -1,0 +1,35 @@
+import { Pet } from "@/server/db/models";
+import { getTypedPets } from "@/server/service/pets";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { userId } = req.query;
+  const { method } = req;
+
+  try {
+    switch (method) {
+      case "GET":
+        const pet: Pet | null = await getTypedPets(Number(userId));
+
+        //Check if user has a pet
+        if (pet) {
+          res.status(200).json(pet);
+        } else {
+          res.status(404).json({ message: "This user doesn't have a pet" });
+        }
+        break;
+
+      default:
+        // Method not allowed
+        res.setHeader("Allow", ["GET", "PATCH", "DELETE"]);
+        res.status(405).end(`Method ${method} Not Allowed`);
+    }
+  } catch (error) {
+    res
+      .status(500)
+      .json({ error: (error as Error).message || "An unknown error occurred" });
+  }
+}

--- a/src/pages/api/v1/pets/[userId].ts
+++ b/src/pages/api/v1/pets/[userId].ts
@@ -1,6 +1,6 @@
 import { Pet } from "@/server/db/models";
 import {
-  getTypedPets,
+  getTypedPet,
   typedDeletePet,
   typedUpdatePet,
   UpdatePetBody,
@@ -21,7 +21,7 @@ export default async function handler(
   try {
     switch (method) {
       case "GET":
-        const pet: Pet | null = await getTypedPets(Number(userId));
+        const pet: Pet | null = await getTypedPet(Number(userId));
 
         // If null response, this user doesn't have a pet
         if (pet) {

--- a/src/pages/api/v1/pets/[userId].ts
+++ b/src/pages/api/v1/pets/[userId].ts
@@ -1,9 +1,5 @@
 import { Pet } from "@/server/db/models";
-import {
-  getTypedPet,
-  typedDeletePet,
-  typedUpdatePet,
-} from "@/server/service/pets";
+import { getPet, deletePet, updatePet } from "@/server/service/pets";
 import { CustomError } from "@/utils/types/exceptions";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -22,7 +18,7 @@ export default async function handler(
     switch (method) {
       case "GET":
         try {
-          const pet: Pet | null = await getTypedPet(userId);
+          const pet: Pet | null = await getPet(userId);
           res.status(200).json(pet);
         } catch (error) {
           if (error instanceof CustomError) {
@@ -36,8 +32,8 @@ export default async function handler(
 
       case "PATCH":
         try {
-          await typedUpdatePet(userId, body);
-          res.status(204).json({});
+          await updatePet(userId, body.name);
+          res.status(204).end();
         } catch (error) {
           if (error instanceof CustomError) {
             res.status(error.statusCode).json({ error: error.message });
@@ -50,8 +46,8 @@ export default async function handler(
 
       case "DELETE":
         try {
-          await typedDeletePet(userId);
-          res.status(204).json({});
+          await deletePet(userId);
+          res.status(204).end();
         } catch (error) {
           if (error instanceof CustomError) {
             res.status(error.statusCode).json({ error: error.message });
@@ -65,7 +61,7 @@ export default async function handler(
       default:
         // Method not allowed
         res.setHeader("Allow", ["GET", "PATCH", "DELETE"]);
-        res.status(405).end(`Method ${method} Not Allowed`);
+        res.status(405).end({ error: `Method ${method} Not Allowed` });
     }
   } catch (error) {
     res

--- a/src/pages/api/v1/pets/index.ts
+++ b/src/pages/api/v1/pets/index.ts
@@ -1,0 +1,46 @@
+import { Pet } from "@/server/db/models";
+import { CreatePetBody, typedCreatePet } from "@/server/service/pets";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { method, body } = req;
+
+  try {
+    switch (method) {
+      case "POST":
+        const createBody: CreatePetBody = body;
+        console.log(createBody);
+        if (
+          !createBody ||
+          typeof createBody.name !== "string" ||
+          createBody.name.trim() === "" ||
+          isNaN(Number(createBody.userId))
+        ) {
+          return res.status(400).json({
+            error:
+              "Invalid request body: 'name' is required and must be a non-empty string, 'userId' is required and must be a number.",
+          });
+        }
+
+        const createdPet: Pet = await typedCreatePet(
+          Number(createBody.userId),
+          createBody.name,
+        );
+
+        res.status(200).json(createdPet);
+        break;
+
+      default:
+        // Method not allowed
+        res.setHeader("Allow", ["POST"]);
+        res.status(405).end(`Method ${method} Not Allowed`);
+    }
+  } catch (error) {
+    res
+      .status(500)
+      .json({ error: (error as Error).message || "An unknown error occurred" });
+  }
+}

--- a/src/pages/api/v1/pets/index.ts
+++ b/src/pages/api/v1/pets/index.ts
@@ -12,7 +12,7 @@ export default async function handler(
     switch (method) {
       case "POST":
         const createBody: CreatePetBody = body;
-        console.log(createBody);
+
         if (
           !createBody ||
           typeof createBody.name !== "string" ||

--- a/src/pages/api/v1/pets/index.ts
+++ b/src/pages/api/v1/pets/index.ts
@@ -1,5 +1,5 @@
 import { Pet } from "@/server/db/models";
-import { typedCreatePet } from "@/server/service/pets";
+import { createPet } from "@/server/service/pets";
 import { CustomError } from "@/utils/types/exceptions";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -12,7 +12,7 @@ export default async function handler(
   try {
     if (method == "POST") {
       try {
-        const createdPet: Pet = await typedCreatePet(body);
+        const createdPet: Pet = await createPet(body.userId, body.name);
         res.status(200).json(createdPet);
       } catch (error) {
         if (error instanceof CustomError) {
@@ -24,7 +24,7 @@ export default async function handler(
     } else {
       // Method not allowed
       res.setHeader("Allow", ["POST"]);
-      res.status(405).end(`Method ${method} Not Allowed`);
+      res.status(405).end({ error: `Method ${method} Not Allowed` });
     }
   } catch (error) {
     res

--- a/src/server/db/actions/pets.ts
+++ b/src/server/db/actions/pets.ts
@@ -3,7 +3,7 @@ import client from "../dbClient";
 import { Pet } from "../models";
 import { CustomError } from "@/utils/types/exceptions";
 
-export async function createPet(newPet: Pet) {
+export async function createNewPet(newPet: Pet) {
   const db = client.db();
 
   try {
@@ -16,43 +16,29 @@ export async function createPet(newPet: Pet) {
   }
 }
 
-export async function getPetByUserId(id: ObjectId) {
+export async function getPetByUserId(userId: ObjectId) {
   const db = client.db();
-  const pet = await db.collection("pets").findOne({ userId: id });
+  const pet = await db.collection("pets").findOne({ userId: userId });
 
   return pet;
 }
 
-export async function updatePetByUserId(id: ObjectId, name: string) {
+export async function updatePetByUserId(userId: ObjectId, name: string) {
   const db = client.db();
-  try {
-    const updatedPet = await db
-      .collection("pets")
-      .findOneAndUpdate(
-        { userId: id },
-        { $set: { name: name } },
-        { returnDocument: "after" },
-      );
+  const result = await db
+    .collection("pets")
+    .updateOne({ userId: userId }, { $set: { name: name } });
 
-    return updatedPet;
-  } catch (error) {
-    throw new CustomError(
-      500,
-      "Failed to update pet: " + (error as Error).message,
-    );
+  if (result.modifiedCount == 0) {
+    throw new CustomError(500, "Failed to update pet.");
   }
 }
 
-export async function deletePetByUserId(id: ObjectId) {
+export async function deletePetByUserId(userId: ObjectId) {
   const db = client.db();
-  try {
-    const pet = await db.collection("pets").findOneAndDelete({ userId: id });
+  const result = await db.collection("pets").deleteOne({ userId: userId });
 
-    return pet;
-  } catch (error) {
-    throw new CustomError(
-      500,
-      "Failed to delete pet: " + (error as Error).message,
-    );
+  if (result.deletedCount == 0) {
+    throw new CustomError(500, "Failed to delete pet.");
   }
 }

--- a/src/server/db/actions/pets.ts
+++ b/src/server/db/actions/pets.ts
@@ -1,34 +1,58 @@
+import { ObjectId } from "mongodb";
 import client from "../dbClient";
 import { Pet } from "../models";
+import { CustomError } from "@/utils/types/exceptions";
 
 export async function createPet(newPet: Pet) {
   const db = client.db();
-  db.collection("pets").insertOne(newPet);
+
+  try {
+    await db.collection("pets").insertOne(newPet);
+  } catch (error) {
+    throw new CustomError(
+      500,
+      "Failed to create pet: " + (error as Error).message,
+    );
+  }
 }
 
-export async function getPetByUserId(id: number) {
+export async function getPetByUserId(id: ObjectId) {
   const db = client.db();
   const pet = await db.collection("pets").findOne({ userId: id });
 
   return pet;
 }
 
-export async function updatePetByUserId(id: number, name: string) {
+export async function updatePetByUserId(id: ObjectId, name: string) {
   const db = client.db();
-  const updatedPet = await db
-    .collection("pets")
-    .findOneAndUpdate(
-      { userId: id },
-      { $set: { name: name } },
-      { returnDocument: "after" },
-    );
+  try {
+    const updatedPet = await db
+      .collection("pets")
+      .findOneAndUpdate(
+        { userId: id },
+        { $set: { name: name } },
+        { returnDocument: "after" },
+      );
 
-  return updatedPet;
+    return updatedPet;
+  } catch (error) {
+    throw new CustomError(
+      500,
+      "Failed to update pet: " + (error as Error).message,
+    );
+  }
 }
 
-export async function deletePetByUserId(id: number) {
+export async function deletePetByUserId(id: ObjectId) {
   const db = client.db();
-  const pet = await db.collection("pets").findOneAndDelete({ userId: id });
+  try {
+    const pet = await db.collection("pets").findOneAndDelete({ userId: id });
 
-  return pet;
+    return pet;
+  } catch (error) {
+    throw new CustomError(
+      500,
+      "Failed to delete pet: " + (error as Error).message,
+    );
+  }
 }

--- a/src/server/db/actions/pets.ts
+++ b/src/server/db/actions/pets.ts
@@ -1,4 +1,10 @@
 import client from "../dbClient";
+import { Pet } from "../models";
+
+export async function createPet(newPet: Pet) {
+  const db = client.db();
+  db.collection("pets").insertOne(newPet);
+}
 
 export async function getPetByUserId(id: number) {
   const db = client.db();

--- a/src/server/db/actions/pets.ts
+++ b/src/server/db/actions/pets.ts
@@ -1,0 +1,9 @@
+import client from "../dbClient";
+
+export async function getPetsByUserId(id: number) {
+  const db = client.db("ican");
+  const collection = db.collection("pets");
+
+  //Retrieve user's one pet
+  return collection.findOne({ userId: id });
+}

--- a/src/server/db/actions/pets.ts
+++ b/src/server/db/actions/pets.ts
@@ -7,7 +7,7 @@ export async function getPetByUserId(id: number) {
   return pet;
 }
 
-export async function updatePetName(id: number, name: string) {
+export async function updatePetByUserId(id: number, name: string) {
   const db = client.db();
   const updatedPet = await db
     .collection("pets")
@@ -18,4 +18,11 @@ export async function updatePetName(id: number, name: string) {
     );
 
   return updatedPet;
+}
+
+export async function deletePetByUserId(id: number) {
+  const db = client.db();
+  const pet = await db.collection("pets").findOneAndDelete({ userId: id });
+
+  return pet;
 }

--- a/src/server/db/actions/pets.ts
+++ b/src/server/db/actions/pets.ts
@@ -1,9 +1,21 @@
 import client from "../dbClient";
 
-export async function getPetsByUserId(id: number) {
-  const db = client.db("ican");
-  const collection = db.collection("pets");
+export async function getPetByUserId(id: number) {
+  const db = client.db();
+  const pet = await db.collection("pets").findOne({ userId: id });
 
-  //Retrieve user's one pet
-  return collection.findOne({ userId: id });
+  return pet;
+}
+
+export async function updatePetName(id: number, name: string) {
+  const db = client.db();
+  const updatedPet = await db
+    .collection("pets")
+    .findOneAndUpdate(
+      { userId: id },
+      { $set: { name: name } },
+      { returnDocument: "after" },
+    );
+
+  return updatedPet;
 }

--- a/src/server/db/models.ts
+++ b/src/server/db/models.ts
@@ -1,7 +1,10 @@
+import { ObjectId } from "mongodb";
+
 export interface Pet {
+  _id?: ObjectId;
   name: string;
   xpGained: number;
   xpLevel: number;
   coins: number;
-  userId: number;
+  userId: ObjectId;
 }

--- a/src/server/db/models.ts
+++ b/src/server/db/models.ts
@@ -1,0 +1,7 @@
+export interface Pet {
+  name: string;
+  xpGained: number;
+  xpLevel: number;
+  coins: number;
+  userId: number;
+}

--- a/src/server/service/pets.ts
+++ b/src/server/service/pets.ts
@@ -1,8 +1,8 @@
-import { getPetsByUserId } from "../db/actions/pets";
+import { getPetByUserId, updatePetName } from "../db/actions/pets";
 import { Pet } from "../db/models";
 
 export async function getTypedPets(id: number): Promise<Pet | null> {
-  const petData = await getPetsByUserId(id);
+  const petData = await getPetByUserId(id);
 
   if (!petData) return null;
 
@@ -16,4 +16,29 @@ export async function getTypedPets(id: number): Promise<Pet | null> {
   } as Pet;
 
   return typedPet;
+}
+
+interface UpdatePetBody {
+  name: string;
+}
+
+export async function typedUpdatePet(
+  id: number,
+  body: UpdatePetBody,
+): Promise<Pet | null> {
+  const updatedPetData = await updatePetName(id, body.name);
+
+  if (!updatedPetData) {
+    return null;
+  }
+
+  const updatedPet: Pet = {
+    name: updatedPetData.value.name,
+    xpGained: updatedPetData.value.xpGained,
+    xpLevel: updatedPetData.value.xpLevel,
+    coins: updatedPetData.value.coins,
+    userId: updatedPetData.value.userId,
+  };
+
+  return updatedPet;
 }

--- a/src/server/service/pets.ts
+++ b/src/server/service/pets.ts
@@ -1,0 +1,19 @@
+import { getPetsByUserId } from "../db/actions/pets";
+import { Pet } from "../db/models";
+
+export async function getTypedPets(id: number): Promise<Pet | null> {
+  const petData = await getPetsByUserId(id);
+
+  if (!petData) return null;
+
+  //Convert data to Pet type
+  const typedPet = {
+    name: petData.name,
+    xpGained: petData.xpGained,
+    xpLevel: petData.xpLevel,
+    coins: petData.coins,
+    userId: petData.userId,
+  } as Pet;
+
+  return typedPet;
+}

--- a/src/server/service/pets.ts
+++ b/src/server/service/pets.ts
@@ -1,5 +1,13 @@
-import { getPetByUserId, updatePetName } from "../db/actions/pets";
+import {
+  deletePetByUserId,
+  getPetByUserId,
+  updatePetByUserId,
+} from "../db/actions/pets";
 import { Pet } from "../db/models";
+
+export interface UpdatePetBody {
+  name: string;
+}
 
 export async function getTypedPets(id: number): Promise<Pet | null> {
   const petData = await getPetByUserId(id);
@@ -18,27 +26,39 @@ export async function getTypedPets(id: number): Promise<Pet | null> {
   return typedPet;
 }
 
-interface UpdatePetBody {
-  name: string;
-}
-
 export async function typedUpdatePet(
   id: number,
-  body: UpdatePetBody,
+  name: string,
 ): Promise<Pet | null> {
-  const updatedPetData = await updatePetName(id, body.name);
+  const updatedPet = await updatePetByUserId(id, name);
 
-  if (!updatedPetData) {
+  if (!updatedPet) {
     return null;
   }
 
-  const updatedPet: Pet = {
-    name: updatedPetData.value.name,
-    xpGained: updatedPetData.value.xpGained,
-    xpLevel: updatedPetData.value.xpLevel,
-    coins: updatedPetData.value.coins,
-    userId: updatedPetData.value.userId,
+  const typedPet: Pet = {
+    name: updatedPet.name,
+    xpGained: updatedPet.xpGained,
+    xpLevel: updatedPet.xpLevel,
+    coins: updatedPet.coins,
+    userId: updatedPet.userId,
   };
 
-  return updatedPet;
+  return typedPet;
+}
+
+export async function typedDeletePet(id: number): Promise<Pet | null> {
+  const deletedPet = await deletePetByUserId(id);
+
+  if (!deletedPet) return null;
+
+  const typedPet = {
+    name: deletedPet.name,
+    xpGained: deletedPet.xpGained,
+    xpLevel: deletedPet.xpLevel,
+    coins: deletedPet.coins,
+    userId: deletedPet.userId,
+  } as Pet;
+
+  return typedPet;
 }

--- a/src/server/service/pets.ts
+++ b/src/server/service/pets.ts
@@ -1,4 +1,5 @@
 import {
+  createPet,
   deletePetByUserId,
   getPetByUserId,
   updatePetByUserId,
@@ -9,7 +10,26 @@ export interface UpdatePetBody {
   name: string;
 }
 
-export async function getTypedPets(id: number): Promise<Pet | null> {
+export interface CreatePetBody {
+  name: string;
+  userId: number;
+}
+
+export async function typedCreatePet(id: number, name: string): Promise<Pet> {
+  const newPet: Pet = {
+    name: name,
+    xpGained: 0,
+    xpLevel: 0,
+    coins: 0,
+    userId: id,
+  };
+
+  await createPet(newPet);
+
+  return newPet;
+}
+
+export async function getTypedPet(id: number): Promise<Pet | null> {
   const petData = await getPetByUserId(id);
 
   if (!petData) return null;

--- a/src/utils/pets.ts
+++ b/src/utils/pets.ts
@@ -1,0 +1,21 @@
+import { InvalidBodyError } from "./types/exceptions";
+import { ObjectId } from "mongodb";
+
+export async function validateParams(
+  userId: string,
+  name?: string,
+): Promise<void> {
+  // Validate parameters
+  if (!ObjectId.isValid(userId)) {
+    throw new InvalidBodyError(
+      "Invalid parameters: 'userId' is required and must be a valid ObjectId.",
+    );
+  }
+
+  // Validate name only if its passed in
+  if (name && (typeof name !== "string" || name.trim() === "")) {
+    throw new InvalidBodyError(
+      "Invalid parameters: 'name' is required and must be a non-empty string.",
+    );
+  }
+}

--- a/src/utils/types/exceptions.ts
+++ b/src/utils/types/exceptions.ts
@@ -1,0 +1,14 @@
+export class CustomError extends Error {
+  statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+export class AlreadyExistsError extends CustomError {
+  constructor(message: string) {
+    super(409, message);
+  }
+}

--- a/src/utils/types/exceptions.ts
+++ b/src/utils/types/exceptions.ts
@@ -12,3 +12,15 @@ export class AlreadyExistsError extends CustomError {
     super(409, message);
   }
 }
+
+export class DoesNotExistError extends CustomError {
+  constructor(message: string) {
+    super(400, message);
+  }
+}
+
+export class InvalidBodyError extends CustomError {
+  constructor(message: string) {
+    super(400, message);
+  }
+}


### PR DESCRIPTION
## API Endpoints to perform CRUD functions for Pets

Issue #9 

### Description
- This PR implements the CRUD operations for pets with API endpoints for creating, accessing, updating, and deleting pets.

### Changes
- Creates pets collection and corresponding type
- Added three API endpoints based on specific user Id:
    - `GET /api/v1/pets/[userId]` which returns the pet with the given userId
    - `PATCH /api/v1/pets/[userId]` which updates the name of the pet with the given userId
    - `DELETE /api/v1/pets/[userId]` which deletes the pet with the given userId
- Added one API endpoint straight to pets:
    - `POST /api/v1/pets` which creates a pet and adds them to the database

### Checklist
- [x] DB collection, schema, and TS types created for Pets models
- [x] On the controller layer, ensure that the /pages/api layer handles HTTP logic, status codes, request body parsing, etc.
- [x] On the service layer, ensure that data validation exists and communicates with the data access layer to perform CRUD for pets
- [x] On the data access layer, ensure that actions exist to create, read, update, or delete pets from MongoDB

### Critical Changes

### Pending
- Potentially using Custom Error type to return errors with proper status code
- Check for duplicate userId in `POST`

### Testing

Tested all endpoints with Postman and local mongoDB
