### PR TITLE
regression: unbreak character background images

### DIFF
--- a/src/components/home/PetDisplay.tsx
+++ b/src/components/home/PetDisplay.tsx
@@ -47,6 +47,7 @@ const PetDisplay: React.FC<PetDisplayProps> = ({
           petType={petType}
           selectedItem={null}
           className="short:w-[300px] minimized:w-[270px] tiny:w-[240px] largeDesktop:w-[350px] desktop:w-[330px] tablet:w-[300px]"
+          showBackground={false}
         />
         <div className="absolute bottom-[90%] left-[90%] tablet:bottom-[75%]">
           <Bubble text={bubbleText} />

--- a/src/components/home/ProfileHeader.tsx
+++ b/src/components/home/ProfileHeader.tsx
@@ -16,7 +16,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
   currentExp,
 }) => {
   return (
-    <div className="flex h-52 w-fit py-8 bg-[#2c3694] justify-start items-center gap-10 mobile:px-2 tablet:px-4 desktop:px-8 largeDesktop:px-10 4xl:h-56 4xl:gap-12 4xl:px-16">
+    <div className="flex h-52 w-fit py-8 justify-start items-center gap-10 mobile:px-2 tablet:px-4 desktop:px-8 largeDesktop:px-10 4xl:h-56 4xl:gap-12 4xl:px-16">
       <ProfilePicture character={petType} />
       <ProfileInfo level={level} coins={coins} currentExp={currentExp} />
     </div>


### PR DESCRIPTION
The tutorial refactor in commit 12c6d55 extracted pet display logic into a separate PetDisplay component, but inadvertently removed the showBackground={false} prop that was present in the original code.

This caused custom backgrounds to incorrectly render on the home page, conflicting with the page's own background styling.
## related
- #140 

<img width="1490" height="921" alt="Screenshot 2025-11-14 at 4 27 48 PM" src="https://github.com/user-attachments/assets/1631f660-c53a-40b2-b1ef-22a4000b875a" />
<img width="2896" height="1732" alt="Screenshot 2025-11-14 at 4 28 00 PM" src="https://github.com/user-attachments/assets/424ba712-327d-435d-9582-6a19ee4a545f" />
