### PR TITLE
Implemented dynamic xp for each level

### DIFF
--- a/src/components/ui/ExpBar.tsx
+++ b/src/components/ui/ExpBar.tsx
@@ -1,13 +1,14 @@
+import { calculateXPForLevel } from "@/utils/constants";
 import Image from "next/image";
 
 interface ExpProps {
   level: number;
   currentExp: number;
-  totalExp?: number;
 }
 
-const ExpBar: React.FC<ExpProps> = ({ level, currentExp, totalExp = 100 }) => {
-  const progress = totalExp > 0 ? (currentExp / totalExp) * 100 : 0;
+const ExpBar: React.FC<ExpProps> = ({ level, currentExp }) => {
+  const xpNeeded = calculateXPForLevel(level);
+  const progress = xpNeeded > 0 ? (currentExp / xpNeeded) * 100 : 0;
 
   return (
     <div className="relative w-fit h-full flex items-center flex-1">
@@ -34,7 +35,7 @@ const ExpBar: React.FC<ExpProps> = ({ level, currentExp, totalExp = 100 }) => {
           </div>
         </div>
         <span className="h-fit z-10 font-quantico font-extrabold text-[2rem] text-white text-stroke-4 text-stroke-[#2A3213] text-shadow-[#444D29] paint-stroke letter-spacing-ui">
-          {currentExp}/{totalExp} XP
+          {currentExp}/{xpNeeded} XP
         </span>
       </div>
     </div>

--- a/src/components/ui/ProfileInfo.tsx
+++ b/src/components/ui/ProfileInfo.tsx
@@ -7,7 +7,6 @@ interface ProfileInfoProps {
   level: number;
   coins: number;
   currentExp: number;
-  totalExp?: number;
 }
 
 const ProfileInfo: React.FC<ProfileInfoProps> = ({
@@ -15,12 +14,11 @@ const ProfileInfo: React.FC<ProfileInfoProps> = ({
   level,
   coins,
   currentExp,
-  totalExp = 100,
 }) => {
   return (
     <div className="flex flex-col h-full w-fit gap-2">
       <ProfileName />
-      <ExpBar level={level} currentExp={currentExp} totalExp={totalExp} />
+      <ExpBar level={level} currentExp={currentExp} />
 
       <div className="flex flex-1 flex-row w-fit items-center gap-3 4xl:gap-4">
         <div className="relative h-full aspect-square">

--- a/src/services/pets.ts
+++ b/src/services/pets.ts
@@ -19,7 +19,7 @@ import {
   validateUpdatePet,
 } from "@/utils/serviceUtils/petsUtil";
 import PetDAO from "@/db/actions/pets";
-import { LEVEL_THRESHOLD, XP_GAIN } from "@/utils/constants";
+import { calculateXPForLevel, XP_GAIN } from "@/utils/constants";
 import { Types } from "mongoose";
 import { Appearance, Pet } from "@/db/models/pet";
 import ERRORS from "@/utils/errorMessages";
@@ -100,6 +100,7 @@ export default class PetService {
 
     const updatedPet: Pet = existingPet;
     updatedPet.food--;
+    const LEVEL_THRESHOLD = calculateXPForLevel(existingPet.xpLevel ?? 0);
     if (updatedPet.xpGained >= LEVEL_THRESHOLD - XP_GAIN) {
       updatedPet.xpLevel += 1;
       updatedPet.coins += 100;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,5 @@
-export const LEVEL_THRESHOLD = 100;
+export const calculateXPForLevel = (level: number): number => {
+  return 90 + level * 10;
+};
 export const XP_GAIN = 5;
 export const FOOD_INC = 1;


### PR DESCRIPTION
## Implemented dynamic xp for each level

Issue Number(s): #157

What does this PR change and why?

Added the dynamic xp req for each level. 90xp for level 0, 100xp for level 1, etc. Didn't need to change tutorial logic because the user only gets 5 xp from that anyway so they cant level up from it.

### Checklist

- [ ] Requirements have been implemented
- [ ] Acceptance criteria is met
- [ ] Database schema docs have been updated or are not necessary
- [ ] Code follows design and style guidelines
- [ ] Commits follow guidelines (concise, squashed, etc)
- [ ] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes
N/A

### Related PRs

- #200

### Testing

Tested manually.
