### PR TITLE
Onboarding & Tutorial Fixes 

### DIFF
--- a/src/components/onboarding/steps/DisclaimerStep.tsx
+++ b/src/components/onboarding/steps/DisclaimerStep.tsx
@@ -31,7 +31,7 @@ export default function DisclaimerStep({
         <OnboardingHeader
           title="Disclaimer"
           titleColor="red"
-          description="This app is not a substitute for medical advice..."
+          description="This app is not a substitute for medical advice. iCAN is not responsible for any missed doses."
           className="text-5xl"
         />
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,10 +16,7 @@ import { useFood } from "@/components/FoodContext";
 import LevelUpModal from "@/components/modals/LevelUpModal";
 import { useState, useEffect, useRef } from "react";
 import { useTutorial } from "@/components/TutorialContext";
-import {
-  useTutorialStatus,
-  useUpdateTutorialStatus,
-} from "@/components/hooks/useAuth";
+import { useTutorialStatus } from "@/components/hooks/useAuth";
 import { useUser } from "@/components/UserContext";
 import { TUTORIAL_PORTIONS } from "@/constants/tutorial";
 import storeItems from "@/lib/storeItems";
@@ -38,7 +35,6 @@ export default function Home({
 }: HomeProps) {
   const { userId } = useUser();
   const { data: tutorialCompleted } = useTutorialStatus(userId);
-  const updateTutorialStatus = useUpdateTutorialStatus();
   const isTutorial = !tutorialCompleted;
 
   const realPetData = usePet();
@@ -194,22 +190,7 @@ export default function Home({
               <NavButton
                 buttonType="help"
                 drawButton={false}
-                redirect=""
-                onClick={() => {
-                  if (userId) {
-                    updateTutorialStatus.mutate(
-                      {
-                        userId,
-                        tutorial_completed: false,
-                      },
-                      {
-                        onSuccess: () => {
-                          window.location.reload();
-                        },
-                      },
-                    );
-                  }
-                }}
+                redirect="/help"
               />
               <NavButton buttonType="settings" drawButton={false} />
             </div>

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -19,6 +19,7 @@ export default function Onboard() {
   const [confirmPin, setConfirmPin] = useState<string>("");
   const [consentChecked, setConsentChecked] = useState<boolean>(false);
   const [pinError, setPinError] = useState<string>("");
+  const [hasSavedParentPin, setHasSavedParentPin] = useState<boolean>(false);
   const { userId } = useUser();
   const updateOnboardingStatus = useUpdateOnboardingStatus();
   const updatePin = useUpdatePin();
@@ -57,6 +58,20 @@ export default function Onboard() {
 
   // Functions to ensure correct states
   const handleChildSetup = () => {
+    if (hasSavedParentPin) {
+      updatePin.mutate(null, {
+        onSuccess: () => {
+          setHasSavedParentPin(false);
+        },
+        onError: (error) => {
+          console.error("Error removing parental pin:", error);
+        },
+      });
+    }
+    setPin("");
+    setConfirmPin("");
+    setPinError("");
+    setConsentChecked(false);
     setUserType("child");
     goToChildConsent();
   };
@@ -85,6 +100,7 @@ export default function Onboard() {
       updatePin.mutate(confirmPin, {
         onSuccess: () => {
           setPinError("");
+          setHasSavedParentPin(true);
           goToParentConsent();
         },
         onError: (error) => {


### PR DESCRIPTION
### Description

Resolves #205 

What does this PR change and why?
- Disclaimer copy now includes the missed‑dose responsibility sentence to meet requirements.
- If a user starts the Parent flow and then switches to Child flow, I removed any saved PIN so parental controls don’t linger incorrectly.
- The help icon now routes to /help and no longer resets tutorial state, keeping tutorial progress consistent.

### Checklist

- [x] Title is same as the ticket title
- [x] The ticket is mentioned above
- [x] The changes fulfill the success criteria of the ticket
- [x] Relevant developers have been assigned
- [x] Relevant reviewers (EM, etc.) have been requested to review

### Critical Changes

None

### Testing

Manually tested locally:
- Disclaimer text updated on onboarding disclaimer screen
- Parent → Child flow clears saved PIN
- Help icon navigates to /help without resetting tutorial state